### PR TITLE
Problem when trimming a Wave from given seconds

### DIFF
--- a/src/com/musicg/wave/Wave.java
+++ b/src/com/musicg/wave/Wave.java
@@ -184,6 +184,15 @@ public class Wave implements Serializable{
 		int rightTrimNumberOfSample = (int) (sampleRate * bitsPerSample / 8
 				* channels * rightTrimSecond);
 
+        // Samples number must be divisible by (bitsPerSample / 8)
+        int residualLeft = leftTrimNumberOfSample % (bitsPerSample / 8);
+        if (residualLeft != 0)
+            leftTrimNumberOfSample -= residualLeft;
+
+        int residualRight = rightTrimNumberOfSample % (bitsPerSample / 8);
+        if (residualRight != 0)
+            rightTrimNumberOfSample -= residualRight;
+
 		trim(leftTrimNumberOfSample, rightTrimNumberOfSample);
 	}
 


### PR DESCRIPTION
When trimming a Wave from given seconds, trimmed samples number must be divisible by the number of bytes per sample. If it's not, we get the first of last sample (depends on if it's left or right trimmed) which is truncated (doesn't contain the right amount of bytes). This is a huge problem when for example concatenating another Wave after the trimmed one which ends with a truncated sample. Indeed, this introduces an offset in bytes, and make the Wave second part unreadable with any Wave player since all samples are wrong.