### PR TITLE
Bug fixed when retrieving chunkSize from a wave file

### DIFF
--- a/src/com/musicg/wave/WaveHeader.java
+++ b/src/com/musicg/wave/WaveHeader.java
@@ -81,7 +81,7 @@ public class WaveHeader {
 			chunkSize = (long) (headerBuffer[pointer++] & 0xff)
 					| (long) (headerBuffer[pointer++] & 0xff) << 8
 					| (long) (headerBuffer[pointer++] & 0xff) << 16
-					| (long) (headerBuffer[pointer++] & 0xff << 24);
+					| (long) (headerBuffer[pointer++] & 0xff) << 24;
 			format = new String(new byte[] { headerBuffer[pointer++],
 					headerBuffer[pointer++], headerBuffer[pointer++],
 					headerBuffer[pointer++] });


### PR DESCRIPTION
This bug made me spend hours to find it!! ;)
When actual chunk size was over 16777216, it wasn't correctly retrieved, because of the badly positioned parenthesis.